### PR TITLE
Using Swift temp url for OS image sent to agent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ env:
 
 install:
 - pip install -v tox
-- pip install -v -e git://github.com/rackerlabs/ironic.git@0a455ccd67d4d709720fa354adebfdccd14ea5a8#egg=ironic
+- pip install -v -e git://github.com/rackerlabs/ironic.git@a721f6d69fa7a4de3a30eb22894c970bd6388b3f#egg=ironic
+
 
 script:
 - tox -vvv -e $TOX_ENV

--- a/ironic_teeth_driver/teeth.py
+++ b/ironic_teeth_driver/teeth.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from ironic.common import exception
+from ironic.common import image_service
 from ironic.common import states
 from ironic.conductor import utils as manager_utils
 from ironic.drivers import base
@@ -80,7 +81,12 @@ class TeethDeploy(base.DeployInterface):
         metadata = node.instance_info.get('metadata')
         files = node.instance_info.get('files')
 
-        # Tell the client to run the image with the given args
+        # Get the swift temp url
+        glance = image_service.Service(version=2)
+        swift_temp_url = glance.swift_temp_url(image_info)
+        image_info['urls'] = [swift_temp_url]
+
+        # Tell the client to download and run the image with the given args
         client = self._get_client()
         client.prepare_image(node, image_info, metadata, files, wait=True)
         # TODO(pcsforeducation) Switch network here

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.0.0
--e git://github.com/rackerlabs/ironic.git@0a455ccd67d4d709720fa354adebfdccd14ea5a8#egg=ironic
+-e git://github.com/rackerlabs/ironic.git@a721f6d69fa7a4de3a30eb22894c970bd6388b3f#egg=ironic


### PR DESCRIPTION
This will create a Swift temp url for the image sent to deploy() and send that to the client in place of the Glance URLs.
